### PR TITLE
Usage of 'next' rather than empty line

### DIFF
--- a/sqlite3_mysql.rb
+++ b/sqlite3_mysql.rb
@@ -7,7 +7,7 @@ ARGF.each do |line|
   or line.include? "BEGIN TRANSACTION" \
   or line.include? "CREATE UNIQUE INDEX" \
   or line.include? "sqlite_sequence"
-    line = ""
+    next
   end
 
   # Words we always want to replace


### PR DESCRIPTION
Using the 'next' keyword skips further execution (such as unnecessary gsub calls) of that item and the next line will be processed instead.